### PR TITLE
Fixed syntax error in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ export default class AutoHeightImage extends PureComponent {
     }
 
     setInitialImageHeight() {
-        const { imageURL, width, onHeightChange } = props;
+        const { imageURL, width, onHeightChange } = this.props;
         const { height = DEFAULT_HEIGHT } = getImageSizeFitWidthFromCache(imageURL, width);
         this.state = { height };
         this.styles = StyleSheet.create({ image: { width, height } });


### PR DESCRIPTION
Syntax error in index.js L49: props is not defined.

Changed props to this.props.