### PR TITLE
update image size on width change

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ export default class AutoHeightImage extends PureComponent {
     }
 
     async updateImageHeight(props) {
-        if (this.state.height === DEFAULT_HEIGHT) {
+        if (
+            this.state.height === DEFAULT_HEIGHT ||
+            this.props.width !== props.width
+        ) {
             // image height could not be `0`
             const { imageURL, width, onHeightChange } = props;
             try {


### PR DESCRIPTION
# What's changed?

This is a fix for issue https://github.com/vivaxy/react-native-auto-height-image/issues/7
Makes the Image update if the width prop has changed.

## Technical description

`updateImageHeight` is called from 2 places:
- `componentDidMount` - in which case it is called with `this.props` so the added check will never be true and have no effect. 
- `componentWillReceiveProps` - where it is called with the new props and the added check will cause it to recalculate if the width has changed even if it already has a height.