### PR TITLE
allowing Image props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import {ImageProps} from "react-native";
 
 interface TSource {
   uri: string;
 }
 
-interface AutoHeightImageProps {
+interface AutoHeightImageProps extends ImageProps  {
   source: number | TSource;
   width: number;
   fallbackSource?: number | TSource;


### PR DESCRIPTION
When adding style to the component, TSLint was complaining that:
`Error:(34, 15) TS2339: Property 'style' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<AutoHeightImage> & Readonly<{ children?: ReactNode; }> & Readonly<AutoHeightImageProps>'.`
This is to resolve this.