### PR TITLE
Safety check in case of 0 width

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -49,6 +49,7 @@ export const getImageSizeFitWidthFromCache = (image, toWidth) => {
   const size = getImageSizeFromCache(image);
   if (size) {
     const { width, height } = size;
+    if (!width || !height) return { width: 0, height: 0 }
     return { width: toWidth, height: toWidth * height / width };
   }
   return {};
@@ -65,5 +66,6 @@ const getImageSizeMaybeFromCache = async (image) => {
 
 export const getImageSizeFitWidth = async (image, toWidth) => {
   const { width, height } = await getImageSizeMaybeFromCache(image);
+  if (!width || !height) return { width: 0, height: 0 }
   return { width: toWidth, height: toWidth * height / width };
 };


### PR DESCRIPTION
I'm trying to load an image that doesn't exist, and therefore returns a height of 0 and width of 0. When calculating height and dividing by width, it returns NaN, which then later causes `Invariant Violation: [29,"RCTImageView",{"height":"<<NaN>>"}] is not usable as a native method argument`. With this fix we return size 0 if the image has 0 height or width.