### PR TITLE
Fixed parameter and return type of onHeightChange function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export interface AutoHeightImageProps extends ImageProps {
   source: number | TSource;
   width: number;
   fallbackSource?: number | TSource;
-  onHeightChange?: () => number;
+  onHeightChange?: (height: number) => void;
 }
 
 declare class AutoHeightImage extends React.Component<


### PR DESCRIPTION
onHeightChange function should takes the `height` parameter and return nothing.
Actual typing so far is that it takes nothing and returns number instead.