### PR TITLE
feat: animated image support

### DIFF
--- a/animatableImage.js
+++ b/animatableImage.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Image, Animated } from 'react-native';
+
+function AnimatableImage(props) {
+  const { animated, ...rest } = props;
+
+  const ImageComponent = animated ? Animated.Image : Image;
+
+  return <ImageComponent {...rest} />;
+}
+
+AnimatableImage.propTypes = {
+  ...Image.propTypes,
+  animated: PropTypes.bool
+};
+
+AnimatableImage.defaultProps = {
+  animated: false
+};
+
+export default AnimatableImage;

--- a/autoHeightImage.js
+++ b/autoHeightImage.js
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import ImagePolyfill from './imagePolyfill';
-import { Image } from 'react-native';
+import Image from './animatableImage';
 import PropTypes from 'prop-types';
 
 import { getImageSizeFitWidth } from './cache';
@@ -39,11 +39,13 @@ function AutoHeightImage(props) {
 AutoHeightImage.propTypes = {
   ...ImagePropTypes,
   width: PropTypes.number.isRequired,
-  onHeightChange: PropTypes.func
+  onHeightChange: PropTypes.func,
+  animated: PropTypes.bool
 };
 
 AutoHeightImage.defaultProps = {
-  onHeightChange: NOOP
+  onHeightChange: NOOP,
+  animated: false
 };
 
 export default AutoHeightImage;

--- a/imagePolyfill.js
+++ b/imagePolyfill.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { Image, Platform } from 'react-native';
+import { Platform } from 'react-native';
+import Image from './animatableImage';
 
 const isAndroid = () => Platform.OS === 'android';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export interface AutoHeightImageProps extends ImageProps {
   width: number;
   fallbackSource?: number | TSource;
   onHeightChange?: (height: number) => void;
+  animated: boolean;
 }
 
 declare class AutoHeightImage extends React.Component<


### PR DESCRIPTION
Hello,
According to #23 , I have made some change for supporting the `Animated.Image`. 

There are two different files using the `Image` component from react-native, so I created `animatableImage.js` to handle the `animated` prop, hope my work helps.