### PR TITLE
fix: android crash at imagePolyfill

### DIFF
--- a/autoHeightImage.js
+++ b/autoHeightImage.js
@@ -4,14 +4,14 @@
  */
 import React, { useEffect, useState } from 'react';
 import ImagePolyfill from './imagePolyfill';
-import Image from './animatableImage';
+import AnimatableImage from './animatableImage';
 import PropTypes from 'prop-types';
 
 import { getImageSizeFitWidth } from './cache';
 import { NOOP, DEFAULT_HEIGHT } from './helpers';
 
 // remove `resizeMode` props from `Image.propTypes`
-const { resizeMode, ...ImagePropTypes } = Image.propTypes;
+const { resizeMode, ...ImagePropTypes } = AnimatableImage.propTypes;
 
 function AutoHeightImage(props) {
   const { onHeightChange, source, width, style, ...rest } = props;
@@ -29,7 +29,7 @@ function AutoHeightImage(props) {
   const imageStyles = { width, height };
 
   // Since it only makes sense to use polyfill with remote images
-  const ImageComponent = source.uri ? ImagePolyfill : Image;
+  const ImageComponent = source.uri ? ImagePolyfill : AnimatableImage;
   return (
     <ImageComponent source={source} style={[imageStyles, style]} {...rest} />
   );

--- a/imagePolyfill.js
+++ b/imagePolyfill.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
-import { Platform } from 'react-native';
-import Image from './animatableImage';
+import { Platform, Image } from 'react-native';
+import AnimatableImage from './animatableImage';
 
 const isAndroid = () => Platform.OS === 'android';
 
@@ -24,10 +24,10 @@ function ImagePolyfill(props) {
     }
   }, [source, onError]);
 
-  return <Image source={source} {...rest} />;
+  return <AnimatableImage source={source} {...rest} />;
 }
 
-ImagePolyfill.propTypes = Image.propTypes;
-ImagePolyfill.defaultProps = Image.defaultProps;
+ImagePolyfill.propTypes = AnimatableImage.propTypes;
+ImagePolyfill.defaultProps = AnimatableImage.defaultProps;
 
 export default ImagePolyfill;


### PR DESCRIPTION
Hi, sorry for the error, the reason is there is no `prefetch` method in `animatableImage`. I think it's better to use `AnimatableImage` instead of just `Image` to avoid errors like this in the future.