### PR TITLE
fix: add missing symbol

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface AutoHeightImageProps extends ImageProps {
   width: number;
   fallbackSource?: number | TSource;
   onHeightChange?: (height: number) => void;
-  animated: boolean;
+  animated?: boolean;
 }
 
 declare class AutoHeightImage extends React.Component<


### PR DESCRIPTION
According to #49, `?` symbol is missing at the prop animated.