### PR TITLE
Make `maxHeight` optional in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ interface TSource {
 export interface AutoHeightImageProps extends ImageProps {
   source: number | TSource;
   width: number;
-  maxHeight: number;
+  maxHeight?: number;
   fallbackSource?: number | TSource;
   onHeightChange?: (height: number) => void;
   animated?: boolean;


### PR DESCRIPTION
As per the README `maxHeight` is optional. This change reflects this in the types of the package.