### PR TITLE
fix caching for images with uri

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -63,7 +63,11 @@ const getImageSizeMaybeFromCache = async (image) => {
   let size = getImageSizeFromCache(image);
   if (!size) {
     size = await loadImageSize(image);
-    cache.set(image, size);
+    if (typeof image === 'number') {
+      cache.set(image, size);
+    } else {
+      cache.set(image.uri, size);
+    }
   }
   return size;
 };


### PR DESCRIPTION
I noticed that my server was getting hit super hard when scrolling in a list of `AutoHeightImage`, turns out the `cache` uses `image.uri` as a key to test if the image is in the cache, but not to save it so it misses 100% of the time.