### PR TITLE
fix: fixed react native warning for deprecated defaultProps

### DIFF
--- a/AnimatableImage.js
+++ b/AnimatableImage.js
@@ -16,8 +16,4 @@ function AnimatableImage(props) {
 
 AnimatableImage.propTypes = Image.propTypes | Animated.Image.propTypes;
 
-AnimatableImage.defaultProps = {
-  animated: false
-};
-
 export default AnimatableImage;

--- a/AutoHeightImage.js
+++ b/AutoHeightImage.js
@@ -13,16 +13,16 @@ import { NOOP, DEFAULT_HEIGHT } from './helpers';
 // remove `resizeMode` props from `Image.propTypes`
 const { resizeMode, ...ImagePropTypes } = AnimatableImage.propTypes;
 
-function AutoHeightImage(props) {
-  const {
-    onHeightChange,
-    source,
-    width,
-    style,
-    maxHeight,
-    onError,
-    ...rest
-  } = props;
+function AutoHeightImage({
+  source,
+  width,
+  style,
+  onError,
+  maxHeight = Infinity,
+  onHeightChange = NOOP,
+  animated = false,
+  ...rest
+}) {
   const [height, setHeight] = useState(
     getImageSizeFitWidthFromCache(source, width, maxHeight).height ||
       DEFAULT_HEIGHT
@@ -80,12 +80,6 @@ AutoHeightImage.propTypes = {
   maxHeight: PropTypes.number,
   onHeightChange: PropTypes.func,
   animated: PropTypes.bool
-};
-
-AutoHeightImage.defaultProps = {
-  maxHeight: Infinity,
-  onHeightChange: NOOP,
-  animated: false
 };
 
 export default AutoHeightImage;

--- a/ImagePolyfill.js
+++ b/ImagePolyfill.js
@@ -28,6 +28,5 @@ function ImagePolyfill(props) {
 }
 
 ImagePolyfill.propTypes = AnimatableImage.propTypes;
-ImagePolyfill.defaultProps = AnimatableImage.defaultProps;
 
 export default ImagePolyfill;


### PR DESCRIPTION
Fix deprecation warning for the use of the defaultProps in react-native 

eg: 
<img height="500" src="https://github.com/user-attachments/assets/b7c0ec20-5cf0-4dda-8c50-ae2cbaa85e58"/>
